### PR TITLE
Fix broken test "test_compilation_error"

### DIFF
--- a/test/test_coffee_script.rb
+++ b/test/test_coffee_script.rb
@@ -44,7 +44,9 @@ class TestCoffeeScript < Minitest::Test
       # 1.6
       "SyntaxError: [stdin]:3:11: unexpected POST_IF",
       # 1.7
-      "SyntaxError: [stdin]:3:11: unexpected unless"
+      "SyntaxError: [stdin]:3:11: unexpected unless",
+      # 2.4.1
+      "[stdin]:3:11: unexpected unless"
     ]
     begin
       src = <<-EOS


### PR DESCRIPTION
Hi there,

I'm in the process of packaging ruby-coffee-script for GNU Guix, and I came across this failing test. Seemed easy enough to fix, so here it is.

Beforehand:

```
Run options: --seed 49250

# Running:

..F....

Finished in 0.107786s, 64.9436 runs/s, 102.0542 assertions/s.

  1) Failure:
TestCoffeeScript#test_compilation_error [/tmp/nix-build-ruby-coffee-script-2.4.1.drv-0/ruby-coffee-script-2.4.1/test/test_coffee_script.rb:70]:
message was "[stdin]:3:11: unexpected unless"
```
