### PR TITLE
restore full context of SyntaxErrors

### DIFF
--- a/lib/coffee_script.rb
+++ b/lib/coffee_script.rb
@@ -18,22 +18,7 @@ module CoffeeScript
 
     COMPILE_FUNCTION_SOURCE = <<-JS
       ;function compile(script, options) {
-        try {
-          var result = CoffeeScript.compile(script, options);
-          if (options.sourceMap === "v3" && result.sourceMap)
-            delete result.sourceMap;
-          return result;
-        } catch (err) {
-          if (err instanceof SyntaxError && err.location) {
-            throw new SyntaxError([
-              err.filename || "[stdin]",
-              err.location.first_line + 1,
-              err.location.first_column + 1
-            ].join(":") + ": " + err.message)
-          } else {
-            throw err;
-          }
-        }
+        return CoffeeScript.compile(script, options);
       }
     JS
 

--- a/test/test_coffee_script.rb
+++ b/test/test_coffee_script.rb
@@ -44,7 +44,7 @@ class TestCoffeeScript < Minitest::Test
       # 1.6
       "SyntaxError: [stdin]:3:11: unexpected POST_IF",
       # 1.7
-      "SyntaxError: [stdin]:3:11: unexpected unless"
+      "[stdin]:3:11: error: unexpected unless\n          unless\n          ^^^^^^"
     ]
     begin
       src = <<-EOS

--- a/test/test_coffee_script.rb
+++ b/test/test_coffee_script.rb
@@ -42,8 +42,10 @@ class TestCoffeeScript < Minitest::Test
       # 1.5
       "Error: Parse error on line 3: Unexpected 'POST_IF'",
       # 1.6
-      "SyntaxError: [stdin]:3:11: unexpected POST_IF",
+      "SyntaxError: unexpected POST_IF",
       # 1.7
+      "SyntaxError: [stdin]:3:11: unexpected unless",
+      # 1.9
       "[stdin]:3:11: error: unexpected unless\n          unless\n          ^^^^^^"
     ]
     begin


### PR DESCRIPTION
@jrolfs / @sstephenson ... this should restore the full context of the coffeescript compilation error, however, it should be noted that it no longer specifically says "SyntaxError" ...
