### PR TITLE
Skip returning the full sourceMap object if we can

### DIFF
--- a/lib/coffee_script.rb
+++ b/lib/coffee_script.rb
@@ -19,7 +19,10 @@ module CoffeeScript
     COMPILE_FUNCTION_SOURCE = <<-JS
       ;function compile(script, options) {
         try {
-          return CoffeeScript.compile(script, options);
+          var result = CoffeeScript.compile(script, options);
+          if (options.sourceMap === "v3" && result.sourceMap)
+            delete result.sourceMap;
+          return result;
         } catch (err) {
           if (err instanceof SyntaxError && err.location) {
             throw new SyntaxError([


### PR DESCRIPTION
If the caller's only interested in the `v3SourceMap`, we can delete the much more complex `sourceMap` object before we have to encode it to pass back to ruby.