### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,10 @@ sudo: false
 rvm:
   - 2.0.0
   - 2.1
-  - 2.2.3
+  - 2.2.7
+  - 2.3.4
+  - 2.4.1
+  - ruby-head
 
 gemfile:
   - test/gemfiles/1.0
@@ -21,3 +24,8 @@ gemfile:
   - test/gemfiles/1.8
   - test/gemfiles/1.9
   - test/gemfiles/1.10
+
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+  fast_finish: true


### PR DESCRIPTION
1. Update Ruby 2.2 to latest version.
2. Add Ruby 2.3, 2.4.
3. Add ruby-head to Travis as allow_failures.

Let me explain more about "3."

I want to add `ruby-head` as allow_failures in `.travis.yml`.
I think this is useful.
Because we can prepare before next version Ruby 2.5 release.
Though it might not be useful until the actual preview release.
We can support the next version as faster.

We can see this kind of logic in `rails/rails`, `rspec` and `cucumber` and etc.

https://github.com/rails/rails/blob/master/.travis.yml
https://github.com/rspec/rspec-core/blob/master/.travis.yml
https://github.com/cucumber/cucumber-ruby/blob/master/.travis.yml

`fast_finish` is to get the Travis result as faster without waiting the result of the "allow_failures" items.
See https://blog.travis-ci.com/2013-11-27-fast-finishing-builds/

Is it possible to add it?

Thanks.