### PR TITLE
Change the link to the repository generating gemspec

### DIFF
--- a/script/build-source-gem
+++ b/script/build-source-gem
@@ -46,7 +46,7 @@ gemspec = Gem::Specification.new do |s|
   s.version   = version
   s.date      = date
 
-  s.homepage    = "http://coffeescript.org"
+  s.homepage    = "https://github.com/rails/ruby-coffee-script"
   s.summary     = "The CoffeeScript Compiler"
   s.description = <<-EOS
     CoffeeScript is a little language that compiles into JavaScript.


### PR DESCRIPTION
Hello.

I have to understand a procedure that [coffee-script-source](https://rubygems.org/gems/coffee-script-source) is uploaded, it took a little time.

Since [build-source-gem](https://github.com/rails/ruby-coffee-script/blob/master/script/build-source-gem) is a tricky mechanism, I felt homepage link was easier to understand by referring to this repository.

Thanks.