### PR TITLE
Update build-source-gem script to support v2.

### DIFF
--- a/script/build-source-gem
+++ b/script/build-source-gem
@@ -13,6 +13,14 @@ if [ ! -d "coffeescript/" ]; then
 fi
 pushd coffeescript/
 
+if [ "$VERSION" == "" ]
+then
+  git fetch --tags
+  VERSION=$(git describe --tags)
+  git checkout "$VERSION"
+  echo "Version is empty. Using latest tag: $VERSION."
+fi
+
 git checkout "$VERSION"
 
 npm install
@@ -20,7 +28,7 @@ npm install
 mkdir -p lib/coffee_script
 
 MINIFY=false ./bin/cake build:browser
-mv docs/v1/browser-compiler/coffee-script.js lib/coffee_script/coffee-script.js
+mv docs/v2/browser-compiler/coffeescript.js lib/coffee_script/coffee-script.js
 
 cat << ERUBY > lib/coffee_script/source.rb
 module CoffeeScript

--- a/script/build-source-gem
+++ b/script/build-source-gem
@@ -28,7 +28,19 @@ npm install
 mkdir -p lib/coffee_script
 
 MINIFY=false ./bin/cake build:browser
-mv docs/v2/browser-compiler/coffeescript.js lib/coffee_script/coffee-script.js
+
+case "$VERSION" in
+1.*)
+  mv docs/v1/browser-compiler/coffee-script.js lib/coffee_script/coffee-script.js
+  ;;
+2.*)
+  mv docs/v2/browser-compiler/coffeescript.js lib/coffee_script/coffee-script.js
+  ;;
+*)
+  echo "NO VALID VERSION DETECTED. FAILING HARD."
+  exit 1
+  ;;
+esac
 
 cat << ERUBY > lib/coffee_script/source.rb
 module CoffeeScript


### PR DESCRIPTION
As far as I understood the coffee-script integration for rails depends on coffee-script-source gem which is built via this script.
I modified the script to use version 2 of the CoffeeScript compiler instead of version 1.
Also I make sure that if no version is set I get the latest tag for the build.