### PR TITLE
CI: Drop unused sudo: false directive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: ruby
 
 cache: bundler
 
-sudo: false
-
 rvm:
   - 2.0.0
   - 2.1


### PR DESCRIPTION
This PR drops a now-unused Travis directive.

See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration for more details