### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/coffee-script.gemspec
+++ b/coffee-script.gemspec
@@ -9,6 +9,12 @@ Gem::Specification.new do |s|
   EOS
   s.license = "MIT"
 
+  s.metadata = {
+    "bug_tracker_uri"   => "https://github.com/rails/ruby-coffee-script/issues",
+    "documentation_uri" => "https://www.rubydoc.info/gems/coffee-script/#{s.version}",
+    "source_code_uri"   => "https://github.com/rails/ruby-coffee-script/tree/v#{s.version}",
+  }
+
   s.files = [
     'lib/coffee-script.rb',
     'lib/coffee_script.rb',

--- a/script/build-source-gem
+++ b/script/build-source-gem
@@ -76,6 +76,8 @@ gemspec = Gem::Specification.new do |s|
     in a simple way.
   EOS
 
+  s.metadata["source_code_uri"] = "https://github.com/rails/ruby-coffee-script/blob/master/script/build-source-gem"
+
   s.files = [
     'lib/coffee_script/coffee-script.js',
     'lib/coffee_script/source.rb'


### PR DESCRIPTION
Add `bug_tracker_uri`, `documentation_uri`, and `source_code_uri` to the gemspec metadata.

These [project metadata](https://guides.rubygems.org/specification-reference/#metadata) will facilitate easy access to project information. The URI will be available on the [Rubygems project page](https://rubygems.org/gems/coffee-script), via the rubygems API, and the `gem` and `bundle` command-line tools with the next release.